### PR TITLE
Add --tz flag for contextual date parsing

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  commands:
+    test:
+      glob: "*.go"
+      run: go test -count=1 ./...
+skip_output:
+  - meta
+  - summary
+  - empty_summary
+  - execution
+  - success
+  - skips

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ My professional swiss army knife / toolkit.
 
 ### `date`
 
+By default, the current system date is returned:
 ```
 ❯ adamctl date
  The time in various places
@@ -19,6 +20,7 @@ My professional swiss army knife / toolkit.
  Turkey       +3:00   Sun Jun 18 22:45:32 +03 2023
 ```
 
+A specific date string can be provided as an argument:
 ```
 ❯ adamctl date "Sun Jun 18 13:18:41 PDT 2023"
  The time in various places
@@ -29,6 +31,7 @@ My professional swiss army knife / toolkit.
 ...
 ```
 
+Or via a pipe:
 ```
 ❯ echo "Sun Jun 18 13:18:41 PDT 2023" | adamctl date
  The time in various places
@@ -38,6 +41,19 @@ My professional swiss army knife / toolkit.
  UTC          +0:00   Sun Jun 18 20:18:41 UTC 2023
 ...
 ```
+
+If a date string is missing timezone information, supply it with `--tz`:
+```
+❯ adamctl date "Sun Jun 18 13:18:41 2023" --tz=UTC
+ The time in various places
+ PLACE        OFFSET  DATE
+ Raw          -7:00   Sun Jun 18 13:18:41 UTC 2023
+ Local        -7:00   Sun Jun 18 06:18:41 PDT 2023
+ UTC          +0:00   Sun Jun 18 13:18:41 UTC 2023
+...
+```
+
+#### Date parsing
 
 Date strings are parsed using [araddon/dateparse](https://github.com/araddon/dateparse):
 ```

--- a/cmd/date.go
+++ b/cmd/date.go
@@ -136,6 +136,7 @@ var dateCmd = &cobra.Command{
 	Long: `A general purpose date parser and printer. Shows useful information about the date. By default shows current date.
 
 Optionally override date value used via argument.`,
+	Args: cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
 		now := time.Now()
 		value := getValueArgument(os.Stdin, args)
@@ -154,7 +155,7 @@ Optionally override date value used via argument.`,
 }
 
 func init() {
-	dateCmd.Flags().String("tz", "", "Contextually parse dates in this timezone instead")
+	dateCmd.Flags().String("tz", "", "contextually parse dates in this timezone instead")
 
 	rootCmd.AddCommand(dateCmd)
 }

--- a/cmd/date_test.go
+++ b/cmd/date_test.go
@@ -21,8 +21,8 @@ func stripAnsi(s string) string {
 func TestRun(t *testing.T) {
 	now := time.Date(2023, time.June, 9, 16, 22, 45, 0, mdt)
 	var out bytes.Buffer
-	err := run(&out, now, "")
 
+	err := run(&out, now, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,8 +46,8 @@ func TestRun(t *testing.T) {
 func TestRunValidDateValue(t *testing.T) {
 	now := time.Date(2023, time.June, 9, 16, 22, 45, 0, mdt)
 	var out bytes.Buffer
-	err := run(&out, now, "Sat Jun 17 14:44:25 PDT 2023")
 
+	err := run(&out, now, "Sat Jun 17 14:44:25 PDT 2023", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,6 +64,31 @@ func TestRunValidDateValue(t *testing.T) {
 		" Denver       -6:00   Sat Jun 17 15:44:25 MDT 2023 \n" +
 		" New York     -4:00   Sat Jun 17 17:44:25 EDT 2023 \n" +
 		" Turkey       +3:00   Sun Jun 18 00:44:25 +03 2023 \n"
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestRunSpecifyTimezone(t *testing.T) {
+	now := time.Date(2023, time.June, 9, 16, 22, 45, 0, mdt)
+	var out bytes.Buffer
+
+	err := run(&out, now, "Sat Jun 17 14:44:25 2023", "UTC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := stripAnsi(out.String())
+
+	expected := "" +
+		" The time in various places                        \n" +
+		" PLACE        OFFSET  DATE                         \n" +
+		" Raw          +0:00   Sat Jun 17 14:44:25 UTC 2023 \n" +
+		" Local        -7:00   Sat Jun 17 07:44:25 PDT 2023 \n" +
+		" UTC          +0:00   Sat Jun 17 14:44:25 UTC 2023 \n" +
+		" Los Angeles  -7:00   Sat Jun 17 07:44:25 PDT 2023 \n" +
+		" Denver       -6:00   Sat Jun 17 08:44:25 MDT 2023 \n" +
+		" New York     -4:00   Sat Jun 17 10:44:25 EDT 2023 \n" +
+		" Turkey       +3:00   Sat Jun 17 17:44:25 +03 2023 \n"
 
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
## Problem
Previously, when `TZ` was used to override a parsed timezone, it would break the "local" time:
```
❯ TZ=UTC adamctl date "Sun Jun 18 13:18:41 2023"
 The time in various places                        
 PLACE        OFFSET  DATE                         
 Raw          +0:00   Sun Jun 18 13:18:41 UTC 2023 
 Local        +0:00   Sun Jun 18 13:18:41 UTC 2023 
 UTC          +0:00   Sun Jun 18 13:18:41 UTC 2023
...
```

## Solution
Make the contextual timezone a flag:
```
❯ ./adamctl date "Sun Jun 18 13:18:41 2023" --tz=UTC
 The time in various places                        
 PLACE        OFFSET  DATE                         
 Raw          +0:00   Sun Jun 18 13:18:41 UTC 2023 
 Local        -7:00   Sun Jun 18 06:18:41 PDT 2023 
 UTC          +0:00   Sun Jun 18 13:18:41 UTC 2023
```